### PR TITLE
[ios] Marker - NMFMarker의 모든 property 및 zIndex, hidden 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ fastlane/readme.md
 node_modules/
 
 .idea/
+
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -212,12 +212,35 @@ interface MarkerProps {
     flat?: boolean
     image?: ImageSourcePropType
     onClick?: () => void
+    width?: number
+    height?: number
+    angle?: number
+    hidden?: boolean
+    zIndex?: number
+    iconPerspectiveEnabled?: boolean
+    isHideCollidedSymbols?: boolean
+    isHideCollidedMarkers?: boolean
+    isHideCollidedCaptions?: boolean;
+    isForceShowIcon?: boolean;
     caption?: {
         text?: string;
         align?: Align;
         textSize?: number;
         color?: string;
         haloColor?: string;
+        offset?: number;
+        requestedWidth?: number;
+        minZoom?: number;
+        maxZoom?: number;
+    };
+    subCaption?: {
+        text?: string;
+        textSize?: number;
+        color?: number;
+        haloColor?: number;
+        requestedWidth?: number;
+        minZoom?: number;
+        maxZoom?: number;
     };
 }
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -149,6 +149,14 @@ export interface MarkerProps extends MapOverlay {
     width?: number;
     height?: number;
     alpha?: number;
+    angle?: number;
+    hidden?: boolean;
+    zIndex?: number;
+    iconPerspectiveEnabled?: boolean;
+    isHideCollidedSymbols?: boolean;
+    isHideCollidedMarkers?: boolean;
+    isHideCollidedCaptions?: boolean;
+    isForceShowIcon?: boolean;
     animated?: boolean;
     caption?: {
         text?: string;
@@ -156,12 +164,19 @@ export interface MarkerProps extends MapOverlay {
         textSize?: number;
         color?: string;
         haloColor?: string;
+        offset?: number;
+        requestedWidth?: number;
+        minZoom?: number;
+        maxZoom?: number;
     };
     subCaption?: {
         text?: string;
         textSize?: number;
         color?: number;
         haloColor?: number;
+        requestedWidth?: number;
+        minZoom?: number;
+        maxZoom?: number;
     };
 }
 export declare class Marker extends Component<MarkerProps> {

--- a/index.js
+++ b/index.js
@@ -106,8 +106,9 @@ export default class NaverMapView extends Component {
 }
 export class Marker extends Component {
     render() {
-        var _a;
-        return React.createElement(RNNaverMapMarker, Object.assign({}, this.props, { image: getImageUri(this.props.image), caption: this.props.caption && Object.assign(Object.assign({}, this.props.caption), { textSize: (_a = this.props.caption.textSize) !== null && _a !== void 0 ? _a : 12, color: parseColor(this.props.caption.color), haloColor: parseColor(this.props.caption.haloColor) }) }));
+        let _a;
+        let _b;
+        return React.createElement(RNNaverMapMarker, Object.assign({}, this.props, { image: getImageUri(this.props.image), caption: this.props.caption && Object.assign(Object.assign({}, this.props.caption), { textSize: (_a = this.props.caption.textSize) !== null && _a !== void 0 ? _a : 12, color: parseColor(this.props.caption.color), haloColor: parseColor(this.props.caption.haloColor) }), subCaption: this.props.subCaption && Object.assign(Object.assign({}, this.props.subCaption), { textSize: (_b = this.props.subCaption.textSize) !== null && _b !== void 0 ? _b : 12, color: parseColor(this.props.subCaption.color), haloColor: parseColor(this.props.subCaption.haloColor) })}));
     }
 }
 export class Circle extends Component {

--- a/index.tsx
+++ b/index.tsx
@@ -226,6 +226,14 @@ export interface MarkerProps extends MapOverlay {
     width?: number;
     height?: number;
     alpha?: number;
+    angle?: number;
+    hidden?: boolean;
+    zIndex?: number;
+    iconPerspectiveEnabled?: boolean;
+    isHideCollidedSymbols?: boolean;
+    isHideCollidedMarkers?: boolean;
+    isHideCollidedCaptions?: boolean;
+    isForceShowIcon?: boolean;
     animated?: boolean;
     caption?: {
         text?: string;
@@ -233,12 +241,19 @@ export interface MarkerProps extends MapOverlay {
         textSize?: number;
         color?: string;
         haloColor?: string;
+        offset?: number;
+        requestedWidth?: number;
+        minZoom?: number;
+        maxZoom?: number;
     };
     subCaption?: {
         text?: string;
         textSize?: number;
         color?: number;
         haloColor?: number;
+        requestedWidth?: number;
+        minZoom?: number;
+        maxZoom?: number;
     };
 }
 

--- a/ios/reactNativeNMap/RNNaverMapMarker.h
+++ b/ios/reactNativeNMap/RNNaverMapMarker.h
@@ -16,10 +16,18 @@
 
 @property (nonatomic, weak) RCTBridge *bridge;
 @property (nonatomic, strong) NMFMarker *realMarker;
-
 @property (nonatomic, assign) NMGLatLng *coordinate;
 @property (nonatomic, assign) CGFloat width;
 @property (nonatomic, assign) CGFloat height;
+@property (nonatomic, assign) NSInteger zIndex;
+@property (nonatomic, assign) BOOL hidden;
+@property (nonatomic, assign) CGFloat angle;
+@property (nonatomic, assign) BOOL flatEnabled;
+@property (nonatomic, assign) BOOL iconPerspectiveEnabled;
+@property (nonatomic, assign) BOOL isHideCollidedSymbols;
+@property (nonatomic, assign) BOOL isHideCollidedMarkers;
+@property (nonatomic, assign) BOOL isHideCollidedCaptions;
+@property (nonatomic, assign) BOOL isForceShowIcon;
 @property (nonatomic, assign) CGFloat rotation;
 @property (nonatomic, copy) NSString *image;
 @property (nonatomic, strong) UIColor *pinColor;
@@ -32,5 +40,15 @@
 - (void)setCaptionColor:(UIColor *) color;
 - (void)setCaptionHaloColor:(UIColor *) color;
 - (void)setCaptionAligns:(NSArray<NMFAlignType *> *) aligns;
-
+- (void)setCaptionOffset:(CGFloat) offset;
+- (void)setCaptionRequestedWidth:(CGFloat) captionWidth;
+- (void)setCaptionMinZoom:(double) minZoom;
+- (void)setCaptionMaxZoom:(double) maxZoom;
+- (void)setSubCaptionText:(NSString *) subText;
+- (void)setSubCaptionTextSize:(CGFloat) subTextSize;
+- (void)setSubCaptionColor:(UIColor *) subColor;
+- (void)setSubCaptionHaloColor:(UIColor *) subHaloColor;
+- (void)setSubCaptionRequestedWidth:(CGFloat) subCaptionWidth;
+- (void)setSubCaptionMinZoom:(double) subMinZoom;
+- (void)setSubCaptionMaxZoom:(double) subMaxZoom;
 @end

--- a/ios/reactNativeNMap/RNNaverMapMarker.m
+++ b/ios/reactNativeNMap/RNNaverMapMarker.m
@@ -46,6 +46,14 @@
   return self;
 }
 
+- (void)setZIndex:(NSInteger) zIndex {
+    _realMarker.zIndex = zIndex;
+}
+
+- (void)setHidden:(BOOL) hidden {
+    _realMarker.hidden = hidden;
+}
+
 - (void)setCoordinate:(NMGLatLng*) coordinate {
   _realMarker.position = coordinate;
 }
@@ -62,18 +70,47 @@
   _realMarker.angle = rotation;
 }
 
-- (void)setPinColor:(UIColor *)pinColor {
+- (void)setPinColor:(UIColor *) pinColor {
   _realMarker.iconTintColor = pinColor;
 }
 
-- (void)setAlpha:(CGFloat)alpha {
+- (void)setAlpha:(CGFloat) alpha {
   _realMarker.alpha = alpha;
 }
 
-- (void)setAnchor:(CGPoint)anchor {
+- (void)setAnchor:(CGPoint) anchor {
   _anchor = anchor;
   _realMarker.anchor = anchor;
 }
+
+- (void)setAngle:(CGFloat) angle {
+    _realMarker.angle = angle;
+}
+
+- (void)setFlatEnabled:(BOOL) flatEnabled {
+    _realMarker.flat = flatEnabled;
+}
+
+- (void)setIconPerspectiveEnabled:(BOOL) iconPerspectiveEnabled {
+    _realMarker.iconPerspectiveEnabled = iconPerspectiveEnabled;
+}
+
+- (void)setisHideCollidedSymbols:(BOOL) isHideCollidedSymbols {
+    _realMarker.isHideCollidedSymbols = isHideCollidedSymbols;
+}
+
+- (void)setIsHideCollidedMarkers:(BOOL) isHideCollidedMarkers {
+    _realMarker.isHideCollidedMarkers = isHideCollidedMarkers;
+}
+
+- (void)setIsHideCollidedCaptions:(BOOL) isHideCollidedCaptions {
+    _realMarker.isHideCollidedCaptions = isHideCollidedCaptions;
+}
+
+- (void)isForceShowIcon:(BOOL) isForceShowIcon {
+    _realMarker.isForceShowIcon = isForceShowIcon;
+}
+
 
 - (void)setMapView:(NMFMapView*) mapView {
   _realMarker.mapView = mapView;
@@ -99,7 +136,50 @@
   _realMarker.captionAligns = aligns;
 }
 
-- (void)setImage:(NSString *)image
+- (void)setCaptionOffset:(CGFloat) offset {
+    _realMarker.captionOffset = offset;
+}
+- (void)setCaptionRequestedWidth:(CGFloat) captionWidth {
+   _realMarker.captionRequestedWidth = captionWidth;
+}
+
+- (void)setCaptionMinZoom:(double) minZoom {
+   _realMarker.captionMinZoom = minZoom;
+}
+
+- (void)setCaptionMaxZoom:(double) maxZoom {
+   _realMarker.captionMaxZoom = maxZoom;
+}
+
+- (void)setSubCaptionText:(NSString *) subText {
+    _realMarker.subCaptionText = subText;
+}
+
+- (void)setSubCaptionTextSize:(CGFloat) subTextSize {
+    _realMarker.subCaptionTextSize = subTextSize;
+}
+
+- (void)setSubCaptionColor:(UIColor *) subColor {
+    _realMarker.subCaptionColor = subColor == nil ? UIColor.blackColor : subColor;
+}
+
+- (void)setSubCaptionHaloColor:(UIColor *) subHaloColor {
+    _realMarker.subCaptionHaloColor = subHaloColor == nil ? UIColor.whiteColor : subHaloColor;
+}
+
+- (void)setSubCaptionRequestedWidth:(CGFloat) subCaptionWidth {
+    _realMarker.subCaptionRequestedWidth = subCaptionWidth;
+}
+
+- (void)setSubCaptionMinZoom:(double) subMinZoom {
+   _realMarker.subCaptionMinZoom = subMinZoom;
+}
+
+- (void)setSubCaptionMaxZoom:(double) subMaxZoom {
+   _realMarker.subCaptionMaxZoom = subMaxZoom;
+}
+
+- (void)setImage:(NSString *) image
 {
   _image = image;
 

--- a/ios/reactNativeNMap/RNNaverMapMarkerManager.m
+++ b/ios/reactNativeNMap/RNNaverMapMarkerManager.m
@@ -30,21 +30,59 @@ RCT_CUSTOM_VIEW_PROPERTY(caption, NSDictionary, RNNaverMapMarker)
   CGFloat textSize = [RCTConvert CGFloat:dic[@"textSize"]];
   UIColor *color = [RCTConvert UIColor:dic[@"color"]];
   UIColor *haloColor = [RCTConvert UIColor:dic[@"haloColor"]];
+  CGFloat offset = [RCTConvert CGFloat:dic[@"offset"]];
+  CGFloat requestedWidth = [RCTConvert CGFloat:dic[@"requestedWidth"]];
+  double minZoom = dic[@"minZoom"] ? [RCTConvert double:dic[@"minZoom"]] : NMF_MIN_ZOOM;
+  double maxZoom = dic[@"maxZoom"] ? [RCTConvert double:dic[@"maxZoom"]] : NMF_MAX_ZOOM;
   NMFAlignType *align = [RCTConvert NMFAlignType:dic[@"align"]];
   NSMutableArray<NMFAlignType *> *alignTypes = [NSMutableArray arrayWithCapacity: 1];
 
   [alignTypes addObject: align];
-
   [view setCaptionText: text];
   [view setCaptionTextSize:textSize];
   [view setCaptionColor:color];
   [view setCaptionHaloColor:haloColor];
+  [view setCaptionOffset:offset];
+  [view setCaptionRequestedWidth:requestedWidth];
+  [view setCaptionMinZoom:minZoom];
+  [view setCaptionMaxZoom:maxZoom];
   [view setCaptionAligns:alignTypes];
 }
+
+RCT_CUSTOM_VIEW_PROPERTY(subCaption, NSDictionary, RNNaverMapMarker)
+{
+  NSDictionary *dic = [RCTConvert NSDictionary:json];
+  NSString *text = [RCTConvert NSString:dic[@"text"]];
+  CGFloat textSize = [RCTConvert CGFloat:dic[@"textSize"]];
+  UIColor *color = [RCTConvert UIColor:dic[@"color"]];
+  UIColor *haloColor = [RCTConvert UIColor:dic[@"haloColor"]];
+  CGFloat requestedWidth = [RCTConvert CGFloat:dic[@"requestedWidth"]];
+  double minZoom = dic[@"minZoom"] ? [RCTConvert double:dic[@"minZoom"]] : NMF_MIN_ZOOM;
+  double maxZoom = dic[@"maxZoom"] ? [RCTConvert double:dic[@"maxZoom"]] : NMF_MAX_ZOOM;
+    
+  [view setSubCaptionText: text];
+  [view setSubCaptionTextSize:textSize];
+  [view setSubCaptionColor:color];
+  [view setSubCaptionHaloColor:haloColor];
+  [view setSubCaptionRequestedWidth:requestedWidth];
+  [view setSubCaptionMinZoom:minZoom];
+  [view setSubCaptionMaxZoom:maxZoom];
+}
+
+
 
 RCT_EXPORT_VIEW_PROPERTY(coordinate, NMGLatLng)
 RCT_EXPORT_VIEW_PROPERTY(width, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(height, CGFloat)
+RCT_EXPORT_VIEW_PROPERTY(zIndex, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(hidden, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(angle, CGFloat)
+RCT_EXPORT_VIEW_PROPERTY(flatEnabled, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(iconPerspectiveEnabled, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(isHideCollidedSymbols, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(isHideCollidedMarkers, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(isHideCollidedCaptions, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(isForceShowIcon, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(rotation, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(image, NSString)
 RCT_EXPORT_VIEW_PROPERTY(pinColor, UIColor)


### PR DESCRIPTION
[NAVER Map iOS SDK](https://navermaps.github.io/ios-map-sdk/reference/index.html) 를 참고하여,
[NMFMarker](https://navermaps.github.io/ios-map-sdk/reference/Classes/NMFMarker.html#/c:objc(cs)NMFMarker(py)tag) 에 명시된 모든 property를 Marker에서 사용 가능하게 수정 및 추가했습니다. 
[NMFOverlay](https://navermaps.github.io/ios-map-sdk/reference/Classes/NMFOverlay.html) 에 명시된 `zIndex`, `hidden` property를 Marker에서 사용 가능하게 추가했습니다.

```typescript
interface MarkerProps {
    coordinate: Coord
    anchor?: { x: number, y: number }
    pinColor?: string
    alpha?: number
    rotation?: number
    flat?: boolean
    image?: ImageSourcePropType
    onClick?: () => void
    width?: number
    height?: number
    angle?: number
    hidden?: boolean
    zIndex?: number
    iconPerspectiveEnabled?: boolean
    isHideCollidedSymbols?: boolean
    isHideCollidedMarkers?: boolean
    isHideCollidedCaptions?: boolean;
    isForceShowIcon?: boolean;
    caption?: {
        text?: string;
        align?: Align;
        textSize?: number;
        color?: string;
        haloColor?: string;
        offset?: number;
        requestedWidth?: number;
        minZoom?: number;
        maxZoom?: number;
    };
    subCaption?: {
        text?: string;
        textSize?: number;
        color?: number;
        haloColor?: number;
        requestedWidth?: number;
        minZoom?: number;
        maxZoom?: number;
    };
}
```