### PR TITLE
[feat]locationTrackingMode : type 추가

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "vscode.tsc.compiler.alertOnError": "never"
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,7 @@ export interface NaverMapViewProps {
     rotateGesturesEnabled?: boolean;
     stopGesturesEnabled?: boolean;
     useTextureView?: boolean;
+    locationTrackingMode?: number;
 }
 export default class NaverMapView extends Component<NaverMapViewProps> {
     ref?: RNNaverMapView;
@@ -118,18 +119,9 @@ export default class NaverMapView extends Component<NaverMapViewProps> {
     setLocationTrackingMode: (mode: number) => void;
     showsMyLocationButton: (show: boolean) => void;
     private dispatchViewManagerCommand;
-    handleOnCameraChange: (event: React.SyntheticEvent<{}, {
-        latitude: number;
-        longitude: number;
-        zoom: number;
-    }>) => void;
-    handleOnMapClick: (event: React.SyntheticEvent<{}, {
-        x: number;
-        y: number;
-        latitude: number;
-        longitude: number;
-    }>) => void;
-    render(): JSX.Element;
+    handleOnCameraChange: (event: any) => any;
+    handleOnMapClick: (event: any) => any;
+    render(): any;
 }
 interface RNNaverMapView extends React.Component<{}, any> {
 }
@@ -165,7 +157,7 @@ export interface MarkerProps extends MapOverlay {
     };
 }
 export declare class Marker extends Component<MarkerProps> {
-    render(): JSX.Element;
+    render(): any;
 }
 export interface CircleProps extends MapOverlay {
     radius?: number;
@@ -175,7 +167,7 @@ export interface CircleProps extends MapOverlay {
     zIndex?: number;
 }
 export declare class Circle extends Component<CircleProps> {
-    render(): JSX.Element;
+    render(): any;
 }
 interface PolylineProps extends Omit<MapOverlay, "coordinate"> {
     coordinates: Coord[];
@@ -183,7 +175,7 @@ interface PolylineProps extends Omit<MapOverlay, "coordinate"> {
     strokeColor?: string;
 }
 export declare class Polyline extends Component<PolylineProps> {
-    render(): JSX.Element;
+    render(): any;
 }
 interface PolygonProps extends Omit<MapOverlay, "coordinate"> {
     coordinates: Coord[];
@@ -193,7 +185,7 @@ interface PolygonProps extends Omit<MapOverlay, "coordinate"> {
     holes?: Coord[][];
 }
 export declare class Polygon extends Component<PolygonProps> {
-    render(): JSX.Element;
+    render(): any;
 }
 export interface PathProps extends Omit<MapOverlay, "coordinate"> {
     coordinates: Coord[];
@@ -209,6 +201,6 @@ export interface PathProps extends Omit<MapOverlay, "coordinate"> {
     zIndex?: number;
 }
 export declare class Path extends Component<PathProps> {
-    render(): JSX.Element;
+    render(): any;
 }
 export {};

--- a/index.tsx
+++ b/index.tsx
@@ -116,6 +116,7 @@ export interface NaverMapViewProps {
     rotateGesturesEnabled?: boolean;
     stopGesturesEnabled?: boolean;
     useTextureView?: boolean;
+    locationTrackingMode?: number;
 }
 
 export default class NaverMapView extends Component<NaverMapViewProps> {


### PR DESCRIPTION
그리고, JS에서 FusedLocation, 
즉 위치를 가져올수있나요?

```
  @Override
    public void onMapReady(@NonNull NaverMap naverMap) {
        this.naverMap = naverMap;
        this.naverMap.setLocationSource(locationSource);
        this.naverMap.setOnMapClickListener(this);
        this.naverMap.addOnCameraIdleListener(this);
        this.naverMap.addOnCameraChangeListener((reason, animated) -> {
            if (reason == -1 && System.currentTimeMillis() - lastTouch > 500) { // changed by user
                WritableMap param = Arguments.createMap();
                param.putInt("reason", reason);
                param.putBoolean("animated", animated);
                emitEvent("onTouch", param);
                lastTouch = System.currentTimeMillis();
            }
        });
        this.naverMap.addOnLocationChangeListener(location->{
           double lat = location.getLatitude();
           double lon = location.getLongitude();

           WritableMap param = Arguments.createMap();
           param.putDouble("longitude", location.getLongitude());
           param.putDouble("latitude", location.getLatitude());

           emitEvent("onLocationChange", param);
        });
        onInitialized();
    }
```

이쪽에 OnLocationChangeListener를 붙이고 js측에서 "onLocationChange"를 사용 가능하게 했는데요.
제가 미쳐 확인 못한 메서드가 있는지 궁금하네요.
아니라면 이부분도 PR하고 싶습니다.

OnCameraChange는 말그대로, 현재 카메라의 좌표이지 실제 기기의 gps가 아니더라구요.