### PR TITLE
마커 이미지가 유효하지 않을 때, iOS crash 나는 문제 수정

### DIFF
--- a/ios/reactNativeNMap/RNNaverMapMarker.m
+++ b/ios/reactNativeNMap/RNNaverMapMarker.m
@@ -210,6 +210,7 @@
                                                                completionBlock:^(NSError *error, UIImage *image) {
                                                                  if (error) {
                                                                    NSLog(@"%@", error);
+                                                                   return;
                                                                  }
                                                                  dispatch_async(dispatch_get_main_queue(), ^{
                                                                    if (self->_iconImageView) [self->_iconImageView removeFromSuperview];


### PR DESCRIPTION
iOS 에서 URL 기반의 이미지를 요청하였으나, 해당 이미지를 획득할 수 없을 때 앱 crash 가 나는 현상을 발견 하였는데요.

해당 이미지를 획득하지 못 했음에도 불구하고, 이후 처리를 시도하려 하기에 crash 를 내는 걸로 분석하였습니다.

그래서 에러가 발생하면 이후 처리를 하지 않도록 `return` 구문을 추가하였는데요.
이 방법이 올바른 해결방법인지는 판단이 서지 않습니다.
(objective-c 쪽 개발 경험이 없어서 판단이 어렵습니다.)

검토 부탁드리겠습니다.