### PR TITLE
Added missing props type - children

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -119,6 +119,7 @@ export interface NaverMapViewProps {
     stopGesturesEnabled?: boolean;
     liteModeEnabled?: boolean;
     useTextureView?: boolean;
+    children?: Element;
 }
 
 export default class NaverMapView extends Component<NaverMapViewProps, {}> {


### PR DESCRIPTION
## 수정 배경
![image](https://user-images.githubusercontent.com/62606632/184566729-4cfcd2dd-e027-4917-89d2-2bbd75ca289a.png)
![image](https://user-images.githubusercontent.com/62606632/184566770-a93e9eb3-aae8-4af3-8a6d-f3a4cebdc113.png)  
```tsx
<NaverMapView><Marker/></NaverMapView>
```  
위 형태로 사용하려 했으나 `NaverMapViewProps` 에 `children`이 정의되어 있지 않아 typescript error가 발생하여 타입 추가해 PR 올립니다.

## 수정 후 
![image](https://user-images.githubusercontent.com/62606632/184566975-82fed800-5904-4ac3-a2ce-0b91bd099cda.png)
수정 후 오류가 나지 않는 모습입니다.  
  
@QuadFlask 