### PR TITLE
fix: android 현재위치 마커 heading 따라 회전 안 되는 이슈

### DIFF
--- a/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapView.java
+++ b/android/src/main/java/com/github/quadflask/react/navermap/RNNaverMapView.java
@@ -68,6 +68,10 @@ public class RNNaverMapView extends MapView implements OnMapReadyCallback, Naver
                 lastTouch = System.currentTimeMillis();
             }
         });
+        naverMap.addOnOptionChangeListener(() -> {
+            LocationTrackingMode mode = naverMap.getLocationTrackingMode();
+            locationSource.setCompassEnabled(mode == LocationTrackingMode.Follow || mode == LocationTrackingMode.Face);
+        });
         onInitialized();
     }
 


### PR DESCRIPTION
tracking mode 가 follow 나 face시에 현재 위치 마커가 디바이스의 방위각 따라 회전하거나 지도가 회전하는 기능이 안되는 것을 수정했습니다.